### PR TITLE
Repaired inconsistent ClaimsIdentity construction in ValidationEndpointTokenProvider 

### DIFF
--- a/source/AccessTokenValidation/ValidationEndpointTokenProvider.cs
+++ b/source/AccessTokenValidation/ValidationEndpointTokenProvider.cs
@@ -54,7 +54,7 @@ namespace Thinktecture.IdentityServer.v3.AccessTokenValidation
                 var result = await _options.ClaimsCache.GetAsync(context.Token);
                 if (result != null)
                 {
-                    context.SetTicket(new AuthenticationTicket(new ClaimsIdentity(result, _options.AuthenticationType), new AuthenticationProperties()));
+                    SetAuthenticationTicket(context, result);
                     return;
                 }
             }
@@ -94,11 +94,16 @@ namespace Thinktecture.IdentityServer.v3.AccessTokenValidation
                 await _options.ClaimsCache.AddAsync(context.Token, claims);
             }
 
+            SetAuthenticationTicket(context, claims);
+        }
+
+        private void SetAuthenticationTicket(AuthenticationTokenReceiveContext context, IEnumerable<Claim> claims)
+        {
             var id = new ClaimsIdentity(
-                claims,
-                _options.AuthenticationType,
-                _options.NameClaimType,
-                _options.RoleClaimType);
+                            claims,
+                            _options.AuthenticationType,
+                            _options.NameClaimType,
+                            _options.RoleClaimType);
 
             context.SetTicket(new AuthenticationTicket(id, new AuthenticationProperties()));
         }


### PR DESCRIPTION
When used claims cache, ClaimsIdentity was not constructed with _options.NameClaimType and                            _options.RoleClaimType but with default ClaimsIdentity.DefaultNameClaimType and ClaimsIdentity.DefaultRoleClaimType. Which leads to inconsistent results and for example IPrincipal.IsInRole not working for cached claims.